### PR TITLE
Fixes #12 - iOS. Disconnect called twice

### DIFF
--- a/Websockets.Ios/WebsocketConnection.cs
+++ b/Websockets.Ios/WebsocketConnection.cs
@@ -148,7 +148,10 @@ namespace Websockets.Ios
             else
                 OnError("Unknown WebSocket Error!");
 
-            OnClosed();
+            if (IsOpen)
+            {
+                OnClosed();
+            }
         }
 
         private void _client_WebSocketClosed(object sender, WebSocketClosedEventArgs e)


### PR DESCRIPTION
I am not sure what was the motivation behind raising OnClosed event in error handling code. In cases I saw SocketRocket raises an error followed by close event, so OnClosed event is raised two times. Maybe it would make sense to remember that OnClosed event was raised and avoid raising it before OnOpened event is called.

The more problematic case is that OnClosed event may be called at start when iPhone has no internet connection available. In such case SocketRocket raises error event with no opened event. This commit fixes this issue.